### PR TITLE
Added Click and Drag, Reorganized Scene Hierarchy

### DIFF
--- a/Assets/Scenes/UI-Mockup.unity
+++ b/Assets/Scenes/UI-Mockup.unity
@@ -94,8 +94,9 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 162864024}
-  - 212: {fileID: 162864023}
+  - 224: {fileID: 162864023}
+  - 222: {fileID: 162864025}
+  - 114: {fileID: 162864024}
   m_Layer: 0
   m_Name: Hand Panel
   m_TagString: Untagged
@@ -103,40 +104,14 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &162864023
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 162864022}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: -1
-  m_Sprite: {fileID: 21300000, guid: 2ef1019f321b81b49852c0ac19bb7b95, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!4 &162864024
-Transform:
+--- !u!224 &162864023
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 162864022}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -4.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.20000005, y: 1.29999995, z: 1}
   m_Children:
   - {fileID: 1754134247}
@@ -144,8 +119,40 @@ Transform:
   - {fileID: 1228107049}
   - {fileID: 688636417}
   - {fileID: 1198847381}
-  m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_Father: {fileID: 350021228}
+  m_RootOrder: 2
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 0, y: -7.1500001}
+  m_SizeDelta: {x: 11, y: 3.22000003}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &162864024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 162864022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 2ef1019f321b81b49852c0ac19bb7b95, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &162864025
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 162864022}
 --- !u!1 &228630509
 GameObject:
   m_ObjectHideFlags: 0
@@ -153,8 +160,9 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 228630511}
-  - 212: {fileID: 228630510}
+  - 224: {fileID: 228630510}
+  - 114: {fileID: 228630514}
+  - 222: {fileID: 228630511}
   - 114: {fileID: 228630512}
   - 114: {fileID: 228630513}
   m_Layer: 0
@@ -164,44 +172,29 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &228630510
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 228630509}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: e6e959b078f92354da7655250fabd66b, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!4 &228630511
-Transform:
+--- !u!224 &228630510
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 228630509}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.4000001, y: -.699999988, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: .75, y: .75, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_Father: {fileID: 350021228}
+  m_RootOrder: 3
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 5.4000001, y: -2.67000008}
+  m_SizeDelta: {x: 2.71000004, y: 4.07000017}
+  m_Pivot: {x: .5, y: .5}
+--- !u!222 &228630511
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 228630509}
 --- !u!114 &228630512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,6 +217,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3effbe331f3c21b448ee7b091803438d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &228630514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 228630509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: e6e959b078f92354da7655250fabd66b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!1 &287723630
 GameObject:
   m_ObjectHideFlags: 0
@@ -247,15 +261,15 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 287723630}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -.707106829, w: .707106709}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_LocalScale: {x: .125000015, y: .178571463, z: 1}
   m_Children: []
-  m_Father: {fileID: 534058725}
+  m_Father: {fileID: 1676980571}
   m_RootOrder: 0
   m_AnchorMin: {x: .5, y: .5}
   m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: -1.91999996, y: 2.75}
+  m_AnchoredPosition: {x: 3.30357075, y: .0125005245}
   m_SizeDelta: {x: 26, y: 30}
   m_Pivot: {x: .5, y: .5}
 --- !u!114 &287723632
@@ -303,7 +317,7 @@ GameObject:
   - 114: {fileID: 350021225}
   - 114: {fileID: 350021229}
   m_Layer: 5
-  m_Name: Stats Canvas
+  m_Name: Board Canvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -373,9 +387,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 534058725}
+  - {fileID: 741434034}
+  - {fileID: 1676980571}
+  - {fileID: 162864023}
+  - {fileID: 228630510}
+  - {fileID: 515674631}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 4
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -476,9 +494,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1712896407}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 5
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -491,8 +510,9 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 515674632}
-  - 212: {fileID: 515674631}
+  - 224: {fileID: 515674631}
+  - 222: {fileID: 515674633}
+  - 114: {fileID: 515674632}
   m_Layer: 0
   m_Name: Top Panel
   m_TagString: Untagged
@@ -500,108 +520,50 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &515674631
-SpriteRenderer:
+--- !u!224 &515674631
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 515674630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 350021228}
+  m_RootOrder: 4
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 0, y: 8.52999973}
+  m_SizeDelta: {x: 14.5, y: 3.22000003}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &515674632
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 515674630}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 0dbea3236f16bec41a1d5eea9f391371, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!4 &515674632
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 515674630}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 5.80000019, z: 0}
-  m_LocalScale: {x: 1.5, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
---- !u!1 &534058724
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 534058725}
-  - 222: {fileID: 534058727}
-  - 114: {fileID: 534058726}
-  m_Layer: 5
-  m_Name: Stats Panel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &534058725
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 534058724}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 287723631}
-  - {fileID: 671072051}
-  - {fileID: 1047403364}
-  m_Father: {fileID: 350021228}
-  m_RootOrder: 0
-  m_AnchorMin: {x: .5, y: .5}
-  m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: -3.33999991, y: 0}
-  m_SizeDelta: {x: 10, y: 5}
-  m_Pivot: {x: .5, y: .5}
---- !u!114 &534058726
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 534058724}
-  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: .671999991}
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Sprite: {fileID: 0}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!222 &534058727
+--- !u!222 &515674633
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 534058724}
+  m_GameObject: {fileID: 515674630}
 --- !u!1 &671072050
 GameObject:
   m_ObjectHideFlags: 0
@@ -625,15 +587,15 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 671072050}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -.707106829, w: .707106709}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_LocalScale: {x: .125000015, y: .178571463, z: 1}
   m_Children: []
-  m_Father: {fileID: 534058725}
+  m_Father: {fileID: 1676980571}
   m_RootOrder: 1
   m_AnchorMin: {x: .5, y: .5}
   m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: -1.89999998, y: .99000001}
+  m_AnchoredPosition: {x: .160713077, y: -.0124999285}
   m_SizeDelta: {x: 26, y: 30}
   m_Pivot: {x: .5, y: .5}
 --- !u!114 &671072052
@@ -721,7 +683,7 @@ Transform:
   m_LocalPosition: {x: 2.08333325, y: 0, z: 0}
   m_LocalScale: {x: .625, y: .576923072, z: 1}
   m_Children: []
-  m_Father: {fileID: 162864024}
+  m_Father: {fileID: 162864023}
   m_RootOrder: 3
 --- !u!61 &688636419
 BoxCollider2D:
@@ -745,40 +707,36 @@ GameObject:
   m_Component:
   - 224: {fileID: 741434034}
   - 222: {fileID: 741434033}
-  - 212: {fileID: 741434032}
+  - 114: {fileID: 741434032}
+  - 61: {fileID: 741434035}
   m_Layer: 0
   m_Name: Board
-  m_TagString: Untagged
+  m_TagString: Board
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &741434032
-SpriteRenderer:
+--- !u!114 &741434032
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 741434031}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: -2
-  m_Sprite: {fileID: 21300000, guid: 068b94579b482b6409be2c2bed878395, type: 3}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 068b94579b482b6409be2c2bed878395, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!222 &741434033
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -793,15 +751,28 @@ RectTransform:
   m_GameObject: {fileID: 741434031}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1.79999995}
-  m_LocalScale: {x: 1.5, y: 2, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_Father: {fileID: 350021228}
+  m_RootOrder: 0
   m_AnchorMin: {x: .5, y: .5}
   m_AnchorMax: {x: .5, y: .5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 15, y: 20}
   m_Pivot: {x: .5, y: .5}
+--- !u!61 &741434035
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 741434031}
+  m_Enabled: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 1}
+  serializedVersion: 2
+  m_Size: {x: 15, y: 12.5}
 --- !u!1 &775299301
 GameObject:
   m_ObjectHideFlags: 0
@@ -855,7 +826,7 @@ Transform:
   m_LocalPosition: {x: -2.08333325, y: 0, z: 0}
   m_LocalScale: {x: .625, y: .576923072, z: 1}
   m_Children: []
-  m_Father: {fileID: 162864024}
+  m_Father: {fileID: 162864023}
   m_RootOrder: 1
 --- !u!61 &775299305
 BoxCollider2D:
@@ -993,15 +964,15 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1047403363}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -.707106829, w: .707106709}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_LocalScale: {x: .125000015, y: .178571463, z: 1}
   m_Children: []
-  m_Father: {fileID: 534058725}
+  m_Father: {fileID: 1676980571}
   m_RootOrder: 2
   m_AnchorMin: {x: .5, y: .5}
   m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: -1.94000006, y: -1.01999998}
+  m_AnchoredPosition: {x: -3.4285717, y: .0375013351}
   m_SizeDelta: {x: 25, y: 30}
   m_Pivot: {x: .5, y: .5}
 --- !u!114 &1047403365
@@ -1109,7 +1080,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 6
 --- !u!1 &1198847379
 GameObject:
   m_ObjectHideFlags: 0
@@ -1163,7 +1134,7 @@ Transform:
   m_LocalPosition: {x: 4.16666651, y: 0, z: 0}
   m_LocalScale: {x: .625, y: .576923072, z: 1}
   m_Children: []
-  m_Father: {fileID: 162864024}
+  m_Father: {fileID: 162864023}
   m_RootOrder: 4
 --- !u!61 &1198847383
 BoxCollider2D:
@@ -1231,7 +1202,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: .625, y: .576923072, z: 1}
   m_Children: []
-  m_Father: {fileID: 162864024}
+  m_Father: {fileID: 162864023}
   m_RootOrder: 2
 --- !u!61 &1228107051
 BoxCollider2D:
@@ -1383,8 +1354,9 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 1676980572}
-  - 212: {fileID: 1676980571}
+  - 224: {fileID: 1676980571}
+  - 222: {fileID: 1676980573}
+  - 114: {fileID: 1676980572}
   m_Layer: 0
   m_Name: Stats Panel
   m_TagString: Untagged
@@ -1392,44 +1364,53 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &1676980571
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1676980570}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 2ef1019f321b81b49852c0ac19bb7b95, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!4 &1676980572
-Transform:
+--- !u!224 &1676980571
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1676980570}
   m_LocalRotation: {x: 0, y: 0, z: .707106829, w: .707106709}
-  m_LocalPosition: {x: -5.25, y: .899999976, z: 0}
-  m_LocalScale: {x: .560000002, y: .800000012, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: .560000002, y: .800000072, z: 1}
+  m_Children:
+  - {fileID: 287723631}
+  - {fileID: 671072051}
+  - {fileID: 1047403364}
+  m_Father: {fileID: 350021228}
+  m_RootOrder: 1
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: -5.25, y: 3.71000004}
+  m_SizeDelta: {x: 10, y: 3.5}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &1676980572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1676980570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 2ef1019f321b81b49852c0ac19bb7b95, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1676980573
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1676980570}
 --- !u!1 &1712896406
 GameObject:
   m_ObjectHideFlags: 0
@@ -1437,9 +1418,10 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 1712896408}
-  - 212: {fileID: 1712896407}
+  - 224: {fileID: 1712896407}
   - 61: {fileID: 1712896410}
+  - 222: {fileID: 1712896409}
+  - 114: {fileID: 1712896408}
   m_Layer: 0
   m_Name: Opponent's Card
   m_TagString: Untagged
@@ -1447,44 +1429,50 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &1712896407
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1712896406}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 73c405b39d803894ca136d3481444f58, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!4 &1712896408
-Transform:
+--- !u!224 &1712896407
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1712896406}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.4000001, y: 2.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: .75, y: .75, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_Father: {fileID: 442118579}
+  m_RootOrder: 0
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 5.4000001, y: 4.69999981}
+  m_SizeDelta: {x: 2.71000004, y: 4.07000017}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &1712896408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1712896406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 73c405b39d803894ca136d3481444f58, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1712896409
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1712896406}
 --- !u!61 &1712896410
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -1551,7 +1539,7 @@ Transform:
   m_LocalPosition: {x: -4.16666651, y: 0, z: 0}
   m_LocalScale: {x: .625, y: .576923072, z: 1}
   m_Children: []
-  m_Father: {fileID: 162864024}
+  m_Father: {fileID: 162864023}
   m_RootOrder: 0
 --- !u!61 &1754134249
 BoxCollider2D:

--- a/Assets/Scripts/CardObject.cs
+++ b/Assets/Scripts/CardObject.cs
@@ -5,12 +5,16 @@
  * This information is determined by CardInfo
  * 
  * Describes user interaction, such as changing scale on MouseDown and MouseUp
+ * Script for click and drag: http://answers.unity3d.com/questions/12322/drag-gameobject-with-mouse.html
  */
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
 
 public class CardObject : MonoBehaviour {
+
+    // text asset variable to assign the text file to
+    public TextAsset testFile;
 
 	// UI Components
     Text titleText;
@@ -23,6 +27,15 @@ public class CardObject : MonoBehaviour {
 	// Variables to control card scale
     float scaleFactor;
     Vector3 scaleVector;
+
+    // Variables for click and drag
+    Camera mainCam;
+    Vector3 screenPoint;
+    Vector3 offset;
+    Vector3 mousePosition;
+
+    // Variable for handling collisions
+    bool touchingBoard;
     
 	// Reference to this object's CardInfo
     //CardInfo myInfo;
@@ -30,12 +43,10 @@ public class CardObject : MonoBehaviour {
 	// Reference to Tuning object
     Tuning tuning;
 
-	// text asset variable to assign the text file to
-	public TextAsset testFile;
-
     void Start()
     {
         tuning = Tuning.tuning;
+        mainCam = Camera.main;
         scaleFactor = tuning.scaleFactor; // Get scale factor from tuning object
         scaleVector = new Vector3(scaleFactor, scaleFactor); // Great scale vector using scale factor
 	}
@@ -68,17 +79,55 @@ public class CardObject : MonoBehaviour {
         description2.text = cardInfo.desc2;
     }
 
+    void PlayCard()
+    {
+        Debug.Log("This card has been played");
+    }
+
 	void OnMouseDown() {
 		// Grow
 		transform.localScale += scaleVector;
 		// Push to front
 		transform.SetAsLastSibling();
+
+        // Assign screenPoint and offset in case user will drag the mouse
+        screenPoint = mainCam.WorldToScreenPoint(gameObject.transform.position);
+        //mousePosition = new Vector3(Input.mousePosition.x, Input.mousePosition.y, screenPoint.z);
+        offset = gameObject.transform.position - mainCam.ScreenToWorldPoint(getMousePosition());
 	}
 
 	void OnMouseUp() {
 		// Shrink
 		transform.localScale -= scaleVector;
+
+        PlayCard();
 	}
+
+    void OnMouseDrag()
+    {
+        transform.position = mainCam.ScreenToWorldPoint(getMousePosition()) + offset;
+    }
+
+    Vector3 getMousePosition()
+    {
+        return new Vector3(Input.mousePosition.x, Input.mousePosition.y, screenPoint.z);
+    }
+
+    void OnCollisionEnter2D(Collision2D coll)
+    {
+        if (coll.gameObject.tag == "Board")
+        {
+            touchingBoard = true;
+        }
+    }
+
+    void OnCollisionExit2D(Collision2D coll)
+    {
+        if (coll.gameObject.tag == "Board")
+        {
+            touchingBoard = false;
+        }
+    }
 
 	//Function to read lines from a text file asset
 	 void readTextFile()


### PR DESCRIPTION
Modifies:
- UI-Mockup.unity
- CardObject.cs

Scene
- Reorganized Hierarchy
- Moved objects onto Canvases
- Replaced Sprite Renderers with Image components
- Adjusted transforms to better fit the screen

CardObject.cs
- Now contains click and drag (using OnMouseDown, OnMouseUp, and OnMouseDrag)
- Detects when the card has been placed on the board (which activates the PlayCard function on release)
- Has a placeholder functon for when the card is played
- Moved public variable to top of class above private variables (this is just a stylistic preference)
