### PR TITLE
Added Game Popup, Move Terrain Function

### DIFF
--- a/Assets/Prefabs/Popup.prefab
+++ b/Assets/Prefabs/Popup.prefab
@@ -1,0 +1,13 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 0}
+  m_IsPrefabParent: 1

--- a/Assets/Prefabs/Popup.prefab.meta
+++ b/Assets/Prefabs/Popup.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24bc27b21e7321d48b033c1f44a0b0b4
+timeCreated: 1456276622
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CardObject.cs
+++ b/Assets/Scripts/CardObject.cs
@@ -94,7 +94,7 @@ public class CardObject : MonoBehaviour {
         salvageText.text = cardInfo.salvage.ToString();
         description.text = cardInfo.desc;
 
-		Land terrain = GameController.gamecontroller.GetTerrainByName (cardInfo.terrain);
+		Land terrain = GameController.gameController.GetTerrainByName (cardInfo.terrain);
 		backgroundImage = images [0];
 		SetBackgroundImage (terrain.cardArt);
     }

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -13,7 +13,7 @@ public class EnemyBehavior : MonoBehaviour {
 
     void Awake()
     {
-		gameController = GameController.gamecontroller;
+		gameController = GameController.gameController;
         cardPlayer = GetComponent<CardPlayer>();
         cardPlayer.SetName("Enemy");
 		hand = cardPlayer.GetCards();

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class GameController : MonoBehaviour {
 
-	public static GameController gamecontroller;
+	public static GameController gameController;
 
 	// variable to track days passed
 	public int days;
@@ -13,6 +13,7 @@ public class GameController : MonoBehaviour {
 	public Land[] terrains;
 	// variable to track current terrain
 	public Land currTerrain;
+	public int currTerrainIndex;
 
 	private CardGame cardGame;
 	private Deck playerDeck;
@@ -37,7 +38,7 @@ public class GameController : MonoBehaviour {
 	int winSalvage;
 
 	void Awake() {
-		gamecontroller = this;
+		gameController = this;
 	}
 
 	void Start () {
@@ -60,7 +61,8 @@ public class GameController : MonoBehaviour {
 		enemyDeck = cardGame.enemyDeck;
 
 		//Initializes array of traversable terrain as the only current terrain
-		currTerrain = terrains [1];
+		currTerrainIndex = 0;
+		currTerrain = terrains [currTerrainIndex];
         currState = new gameState();
 		currState.setTerrain (currTerrain);
 		phase = 0;
@@ -226,12 +228,25 @@ public class GameController : MonoBehaviour {
 		return GetTerrainByName ("Any");
 	}
 
+	public void MoveTerrain() {
+		if (currTerrainIndex < terrains.Length - 1) {
+			currState.setTerrain (currTerrainIndex + 1);
+		} else {
+			currState.setTerrain(0);
+		}
+	}
+
 	//NOTE: May move below and associated code to more appropriate class.
 	//Tracks the previous terrain type and whether Lex used a shelter there.
 	//This is stored in an array in the parent class for Lex to access.
 	private class gameState {
 		private Land terrainType;
 		private bool shelter;
+		GameController gameController;
+
+		void Start() {
+			gameController = GameController.gameController;
+		}
 
 		public bool getShelter(){
 			return shelter;
@@ -243,13 +258,16 @@ public class GameController : MonoBehaviour {
 
 		public void setTerrain(Land terrain){
 			this.terrainType = terrain;
-			UIManager.UImanager.SetBoard (terrain);
+			UIManager.UImanager.SetBoard (terrainType);
+		}
+
+		public void setTerrain(int terrainIndex) {
+			this.terrainType = GameController.gameController.terrains [terrainIndex];
+			UIManager.UImanager.SetBoard (terrainType);
 		}
 
 		public void setShelter(bool shelterUsed){
 			this.shelter = shelterUsed;
 		}
-
 	}
-
 }

--- a/Assets/Scripts/Popup.cs
+++ b/Assets/Scripts/Popup.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+public class Popup : MonoBehaviour {
+
+	Text messageText;
+
+	void Start() {
+		messageText = GetComponentsInChildren<Text>() [0];
+	}
+
+	public void SetText(string message) {
+		messageText.text = message;
+	}
+
+	public void Dimiss() {
+		gameObject.SetActive (false);
+	}
+}

--- a/Assets/Scripts/Popup.cs.meta
+++ b/Assets/Scripts/Popup.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 61ac17534c4f7244b934bb2a18c030c1
+timeCreated: 1456276332
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tuning.cs
+++ b/Assets/Scripts/Tuning.cs
@@ -24,6 +24,8 @@ public class Tuning : MonoBehaviour {
     public float scaleFactor;
     public Vector3 cardScale;
 
+	public int travelCost;
+
     void Awake()
     {
         tuning = this;

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -17,10 +17,17 @@ public class UIManager : MonoBehaviour {
     public Text goldText;
     public Text salvageText;
 
-	public Image Board;
+	public Button travelButton;
+	public Image board;
+
+	public GameObject popupObject;
 
 	// Reference to player
     Player player;
+
+	Tuning tuning;
+
+	Popup popup;
 
 	void Awake() {
 		UImanager = this;
@@ -28,6 +35,9 @@ public class UIManager : MonoBehaviour {
 
 	void Start () {
         player = Player.player;
+		tuning = Tuning.tuning;
+		popup = popupObject.GetComponent<Popup> ();
+		popupObject.SetActive(false);
 
         /*
         pointsText.text = "Points: ";
@@ -46,6 +56,25 @@ public class UIManager : MonoBehaviour {
     }
 
 	public void SetBoard(Land terrain) {
-		Board.sprite = terrain.boardArt;
+		board.sprite = terrain.boardArt;
+	}
+
+	public void Travel() {
+		if (tuning.travelCost <= player.GetStats () [2]) {
+			// Player can afford
+			GameController.gameController.MoveTerrain();
+			player.ChangeStats (0, 0, -tuning.travelCost);
+		} else {
+			showPopup();
+		}
+	}
+
+	public void DismissPopup() {
+		popup.Dimiss ();
+	}
+
+	void showPopup() {
+		popupObject.SetActive (true);
+		popup.SetText ("You do not have enough salvage to travel.");
 	}
 }


### PR DESCRIPTION
Renamed instance variable of GameController for consistency and fixed its references.
Added Popup prefab with popup functions in UIManager.
Added TravelCost variable to tuning.
When the travel button is pressed, if the player has enough salvage, the terrain will change and their salvage will decrease by the travel cost. If the player can't afford it, a popup will display text saying that they can't afford to travel.
