### PR TITLE
Minor bug fix for MoveTerrain, Popup text

### DIFF
--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -230,7 +230,8 @@ public class GameController : MonoBehaviour {
 
 	public void MoveTerrain() {
 		if (currTerrainIndex < terrains.Length - 1) {
-			currState.setTerrain (currTerrainIndex + 1);
+			currTerrainIndex++;
+			currState.setTerrain (currTerrainIndex);
 		} else {
 			currState.setTerrain(0);
 		}

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -65,7 +65,7 @@ public class UIManager : MonoBehaviour {
 			GameController.gameController.MoveTerrain();
 			player.ChangeStats (0, 0, -tuning.travelCost);
 		} else {
-			showPopup();
+			showPopup("I'm sorry. You do not have enough salvage to travel.");
 		}
 	}
 
@@ -73,8 +73,8 @@ public class UIManager : MonoBehaviour {
 		popup.Dimiss ();
 	}
 
-	void showPopup() {
+	void showPopup(string message) {
 		popupObject.SetActive (true);
-		popup.SetText ("You do not have enough salvage to travel.");
+		popup.SetText (message);
 	}
 }


### PR DESCRIPTION
Bug fix: MoveTerrain() would only go to one location because currTerrainIndex was never updated.
ShowPopup now takes in a string as input to display on the popup.
