### PR TITLE
Confirmation Prompt, CardPlayer Subclassing

### DIFF
--- a/Assets/Scenes/UI-Mockup.unity
+++ b/Assets/Scenes/UI-Mockup.unity
@@ -87,6 +87,121 @@ NavMeshSettings:
     cellSize: .166666672
     manualCellSize: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &15144605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 15144606}
+  - 222: {fileID: 15144609}
+  - 114: {fileID: 15144608}
+  - 114: {fileID: 15144607}
+  m_Layer: 5
+  m_Name: Yes Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &15144606
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15144605}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 529299525}
+  m_Father: {fileID: 788665025}
+  m_RootOrder: 1
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: -2, y: -1}
+  m_SizeDelta: {x: 3, y: 1.5}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &15144607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15144605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: .960784316, g: .960784316, b: .960784316, a: 1}
+    m_PressedColor: {r: .239215687, g: .239215687, b: .239215687, a: 1}
+    m_DisabledColor: {r: .784313738, g: .784313738, b: .784313738, a: .501960814}
+    m_ColorMultiplier: 1
+    m_FadeDuration: .100000001
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 15144608}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1353636834}
+        m_MethodName: Confirm
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &15144608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15144605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: .316176474, g: .316176474, b: .316176474, a: 1}
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &15144609
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 15144605}
 --- !u!1 &59471136
 GameObject:
   m_ObjectHideFlags: 0
@@ -367,17 +482,6 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 73c405b39d803894ca136d3481444f58, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!224 &228630510 stripped
-RectTransform:
-  m_PrefabParentObject: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140,
-    type: 2}
-  m_PrefabInternal: {fileID: 1281688598}
---- !u!114 &228630512 stripped
-MonoBehaviour:
-  m_PrefabParentObject: {fileID: 11451466, guid: 17d3c83cec127874f957c5c78bef5140,
-    type: 2}
-  m_PrefabInternal: {fileID: 1281688598}
-  m_Script: {fileID: 11500000, guid: 425381c94e4fd884cbb5c2ec4879a132, type: 3}
 --- !u!1 &287723630
 GameObject:
   m_ObjectHideFlags: 0
@@ -706,10 +810,7 @@ RectTransform:
   - {fileID: 162864023}
   - {fileID: 59471137}
   - {fileID: 1712896407}
-  - {fileID: 1220095516}
   - {fileID: 442118579}
-  - {fileID: 573534736}
-  - {fileID: 228630510}
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_AnchorMin: {x: 0, y: 0}
@@ -717,6 +818,72 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 13.5, y: 20}
   m_Pivot: {x: .5, y: .5}
+--- !u!1 &398545809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 398545810}
+  - 222: {fileID: 398545812}
+  - 114: {fileID: 398545811}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &398545810
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 398545809}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1828459934}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &398545811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 398545809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 5
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: No
+--- !u!222 &398545812
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 398545809}
 --- !u!1 &422077548
 GameObject:
   m_ObjectHideFlags: 0
@@ -904,7 +1071,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 350021228}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 6.75, y: 10}
@@ -1088,119 +1255,72 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 515674630}
---- !u!1001 &573534735
-Prefab:
+--- !u!1 &529299524
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 350021228}
-    m_Modifications:
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 5.39999962
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -2.67000008
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 2.71000004
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 4.07000017
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMin.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMin.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMax.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMax.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Pivot.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Pivot.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 111308, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Name
-      value: Enemy Deck
-      objectReference: {fileID: 0}
-    - target: {fileID: 11430812, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalScale.x
-      value: .75
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalScale.y
-      value: .75
-      objectReference: {fileID: 0}
-    - target: {fileID: 11451466, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: DeckType
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-  m_IsPrefabParent: 0
---- !u!224 &573534736 stripped
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 529299525}
+  - 222: {fileID: 529299527}
+  - 114: {fileID: 529299526}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &529299525
 RectTransform:
-  m_PrefabParentObject: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140,
-    type: 2}
-  m_PrefabInternal: {fileID: 573534735}
---- !u!114 &573534737 stripped
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529299524}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 15144606}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &529299526
 MonoBehaviour:
-  m_PrefabParentObject: {fileID: 11451466, guid: 17d3c83cec127874f957c5c78bef5140,
-    type: 2}
-  m_PrefabInternal: {fileID: 573534735}
-  m_Script: {fileID: 11500000, guid: 425381c94e4fd884cbb5c2ec4879a132, type: 3}
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529299524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 5
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: Yes
+--- !u!222 &529299527
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529299524}
 --- !u!1 &688636415
 GameObject:
   m_ObjectHideFlags: 0
@@ -1478,6 +1598,73 @@ BoxCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Size: {x: 2.71000004, y: 4.07000017}
+--- !u!1 &788665024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 164542, guid: 24bc27b21e7321d48b033c1f44a0b0b4, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 788665025}
+  - 222: {fileID: 788665027}
+  - 114: {fileID: 788665026}
+  m_Layer: 5
+  m_Name: Confirmation Prompt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &788665025
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 22429370, guid: 24bc27b21e7321d48b033c1f44a0b0b4,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 788665024}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2106856782}
+  - {fileID: 15144606}
+  - {fileID: 1828459934}
+  m_Father: {fileID: 1353636833}
+  m_RootOrder: 4
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: -259, y: -345}
+  m_SizeDelta: {x: 8, y: 5}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &788665026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11435054, guid: 24bc27b21e7321d48b033c1f44a0b0b4,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 788665024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: .428000003}
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &788665027
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 22221950, guid: 24bc27b21e7321d48b033c1f44a0b0b4,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 788665024}
 --- !u!1 &805710380
 GameObject:
   m_ObjectHideFlags: 0
@@ -1666,6 +1853,7 @@ MonoBehaviour:
   isSisterAlive: 0
   isGrandmaAlive: 0
   UImanager: {fileID: 0}
+  tuning: {fileID: 0}
 --- !u!114 &891024543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1677,10 +1865,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dde2ebf6ddae58e4d861e8dc419c33c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 1029208978}
-  enemy: {fileID: 1111293362}
-  playerDeck: {fileID: 228630512}
-  enemyDeck: {fileID: 573534737}
+  player: {fileID: 1029208976}
+  enemy: {fileID: 1111293360}
   playerHandTargets:
   - {fileID: 1754134247}
   - {fileID: 775299303}
@@ -1841,6 +2027,7 @@ GameObject:
   - 4: {fileID: 1029208977}
   - 114: {fileID: 1029208976}
   - 114: {fileID: 1029208978}
+  - 114: {fileID: 1029208979}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -1859,7 +2046,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 05bb96f655026c247bfb354f3fd511c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  UImanager: {fileID: 0}
 --- !u!4 &1029208977
 Transform:
   m_ObjectHideFlags: 0
@@ -1883,6 +2069,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcaf76672fa77f04884f86b6162de33b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1029208979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1029208975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425381c94e4fd884cbb5c2ec4879a132, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DeckType: 0
 --- !u!1 &1111293359
 GameObject:
   m_ObjectHideFlags: 0
@@ -1893,6 +2091,7 @@ GameObject:
   - 4: {fileID: 1111293361}
   - 114: {fileID: 1111293360}
   - 114: {fileID: 1111293362}
+  - 114: {fileID: 1111293363}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Untagged
@@ -1934,6 +2133,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcaf76672fa77f04884f86b6162de33b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1111293363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1111293359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 425381c94e4fd884cbb5c2ec4879a132, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DeckType: 1
 --- !u!1 &1177638587
 GameObject:
   m_ObjectHideFlags: 0
@@ -2085,132 +2296,6 @@ BoxCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Size: {x: 2.71000004, y: 4.07000017}
---- !u!1 &1220095515
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 1220095516}
-  - 222: {fileID: 1220095519}
-  - 114: {fileID: 1220095518}
-  - 114: {fileID: 1220095517}
-  m_Layer: 5
-  m_Name: Travel Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1220095516
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1220095515}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1785302232}
-  m_Father: {fileID: 350021228}
-  m_RootOrder: 4
-  m_AnchorMin: {x: .5, y: .5}
-  m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: 5.0999999, y: 1}
-  m_SizeDelta: {x: 2.5, y: 2}
-  m_Pivot: {x: .5, y: .5}
---- !u!114 &1220095517
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1220095515}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: .960784316, g: .960784316, b: .960784316, a: 1}
-    m_PressedColor: {r: .784313738, g: .784313738, b: .784313738, a: 1}
-    m_DisabledColor: {r: .784313738, g: .784313738, b: .784313738, a: .501960814}
-    m_ColorMultiplier: 1
-    m_FadeDuration: .100000001
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1220095518}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_MethodName: Travel
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_MethodName: PlayButtonPressSFX
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!114 &1220095518
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1220095515}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Sprite: {fileID: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &1220095519
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1220095515}
 --- !u!1 &1228107047
 GameObject:
   m_ObjectHideFlags: 0
@@ -2279,113 +2364,6 @@ BoxCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Size: {x: 2.71000004, y: 4.07000017}
---- !u!1001 &1281688598
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 350021228}
-    m_Modifications:
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 5.0999999
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -2.67000008
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 2.91300011
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMin.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMin.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMax.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_AnchorMax.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Pivot.x
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Pivot.y
-      value: .5
-      objectReference: {fileID: 0}
-    - target: {fileID: 111308, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Name
-      value: Player Deck
-      objectReference: {fileID: 0}
-    - target: {fileID: 11430812, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: b329ca8930da57b4c9456f2b4ab4cec5,
-        type: 3}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 22484206, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 11430812, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 11451466, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-      propertyPath: DeckType
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 17d3c83cec127874f957c5c78bef5140, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &1322905280
 GameObject:
   m_ObjectHideFlags: 0
@@ -2486,6 +2464,7 @@ RectTransform:
   - {fileID: 1366875306}
   - {fileID: 1185975798}
   - {fileID: 995315276}
+  - {fileID: 788665025}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_AnchorMin: {x: 0, y: 0}
@@ -2507,7 +2486,8 @@ MonoBehaviour:
   pointsText: {fileID: 287723632}
   board: {fileID: 741434032}
   pauseMenu: {fileID: 995315275}
-  popupObject: {fileID: 1185975797}
+  confirmMenu: {fileID: 788665024}
+  notificationPopup: {fileID: 1185975797}
 --- !u!114 &1353636835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2851,13 +2831,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c73d38fa12069f140bf87fbdbf24a46e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  numOfCardsToWin: 25
+  winPoints: 0
   startingGold: 0
   startingSalvage: 0
   startingPoints: 0
   numOfStartingCards: 5
+  handLimit: 0
   scaleFactor: .600000024
   cardScale: {x: .150000006, y: .150000006, z: 0}
+  enemyWaitTime: 0
   travelCost: 1
   defaultDismissButtonText: Dismiss
 --- !u!4 &1507072009
@@ -3163,74 +3145,6 @@ BoxCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Size: {x: 2.71000004, y: 4.07000017}
---- !u!1 &1785302231
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
-  m_Component:
-  - 224: {fileID: 1785302232}
-  - 222: {fileID: 1785302234}
-  - 114: {fileID: 1785302233}
-  m_Layer: 5
-  m_Name: TravelText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1785302232
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1785302231}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1220095516}
-  m_RootOrder: 0
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: .5, y: .5}
---- !u!114 &1785302233
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1785302231}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: .196078435, g: .196078435, b: .196078435, a: 1}
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 4
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 'Travel
-
-    Cost: 1 Slvg'
---- !u!222 &1785302234
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1785302231}
 --- !u!1 &1806891613
 GameObject:
   m_ObjectHideFlags: 0
@@ -3346,6 +3260,121 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1806891613}
+--- !u!1 &1828459933
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 1828459934}
+  - 222: {fileID: 1828459937}
+  - 114: {fileID: 1828459936}
+  - 114: {fileID: 1828459935}
+  m_Layer: 5
+  m_Name: No Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1828459934
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828459933}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 398545810}
+  m_Father: {fileID: 788665025}
+  m_RootOrder: 2
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 2, y: -1}
+  m_SizeDelta: {x: 3, y: 1.5}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &1828459935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828459933}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: .960784316, g: .960784316, b: .960784316, a: 1}
+    m_PressedColor: {r: .239215687, g: .239215687, b: .239215687, a: 1}
+    m_DisabledColor: {r: .784313738, g: .784313738, b: .784313738, a: .501960814}
+    m_ColorMultiplier: 1
+    m_FadeDuration: .100000001
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1828459936}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1353636834}
+        m_MethodName: Confirm
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1828459936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828459933}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: .313725501, g: .313725501, b: .313725501, a: 1}
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1828459937
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828459933}
 --- !u!1 &2094843806
 GameObject:
   m_ObjectHideFlags: 0
@@ -3461,6 +3490,72 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2094843806}
+--- !u!1 &2106856781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 2106856782}
+  - 222: {fileID: 2106856784}
+  - 114: {fileID: 2106856783}
+  m_Layer: 5
+  m_Name: Confirmation Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2106856782
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2106856781}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: .100000001, y: .100000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 788665025}
+  m_RootOrder: 0
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 70, y: 25}
+  m_Pivot: {x: .5, y: .5}
+--- !u!114 &2106856783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2106856781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: .196078435, g: .196078435, b: .196078435, a: 1}
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 7
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Are you sure you want to do that?
+--- !u!222 &2106856784
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2106856781}
 --- !u!1 &2112049464
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardGame.cs
+++ b/Assets/Scripts/CardGame.cs
@@ -13,13 +13,11 @@ using System.Collections;
 using System.Collections.Generic;
 
 public class CardGame : MonoBehaviour {
+
 	public static CardGame Instance;
 
-    public CardPlayer player;
-    public CardPlayer enemy;
-
-    public Deck playerDeck; // Reference to Deck from Player Deck GameObject
-    public Deck enemyDeck; // Reference to Deck from Enemy Deck GameObject
+    public Player player; // Inherits from CardPlayer
+    public EnemyBehavior enemy; // Inherits from CardPlayer
 
     public Transform[] playerHandTargets; // Array of transforms for each card in the player's hand
     public Transform[] enemyHandTargets; // Array of transforms for each card in enemy's hand
@@ -30,8 +28,11 @@ public class CardGame : MonoBehaviour {
     public GameObject enemyCardTemplate; // Reference to enemy card prefab
     public GameObject cardCanvas; // Reference to canvas containing cards
 
-    List<CardObject> playerCards; // Reference to cards from Player's CardPlayer
-    List<CardObject> enemyCards; // Reference to cards from Enemy's CardPlayer
+	Deck playerDeck; // Reference to Deck from Player
+	Deck enemyDeck; // Reference to Deck from EnemyBehavior
+
+    List<CardObject> playerCards; // Reference to cards in Player's hand
+    List<CardObject> enemyCards; // Reference to cards from Enemy's hand
 
     Tuning tuning; // Reference to tuning object
     int numOfStartingCards; // Number of cards each card player starts with
@@ -41,26 +42,33 @@ public class CardGame : MonoBehaviour {
 		Instance = this;
 	}
 
-	public void SetupCardGame() {
+	public void SetupCardGame(Deck playerDeck, Deck enemyDeck) {
 		tuning = Tuning.tuning;
 		numOfStartingCards = tuning.numOfStartingCards;
 		cardScale = tuning.cardScale;
-		
-		playerCards = player.GetCards();
-		enemyCards = enemy.GetCards();
+
+		this.playerDeck = playerDeck;
+		this.enemyDeck = enemyDeck;
+
+		playerCards = player.GetHand();
+		enemyCards = enemy.GetHand();
 	}
 
 	public void BeginCardGame() {
+
+		//playerDeck = player.GetDeck ();
+		//enemyDeck = enemy.GetDeck ();
 		DealCards(numOfStartingCards, playerDeck, playerHandTargets, player);
 		DealCards(numOfStartingCards, enemyDeck, enemyHandTargets, enemy);
 		
-		showEnemyCard();
+		waitAndShowEnemyCard(tuning.enemyWaitTime);
 	}
 
     // This is called when the card game starts
 	// Deals the number of starting cards to the player
     public void DealCards(int numOfCards, Deck deck, Transform[] handTargets, CardPlayer cardPlayer)
     {
+		deck = cardPlayer.GetDeck ();
         for (int i = 0; i < numOfCards; i++)
         {
             Transform currentTransform = handTargets[i];
@@ -102,11 +110,13 @@ public class CardGame : MonoBehaviour {
 
     // Temporary function
     // Makes enemy play first card and displays it on the board
-    public void showEnemyCard()
+    public IEnumerator waitAndShowEnemyCard(float waitTime)
     {
         CardObject card = enemyCards[0];
         card.transform.position = enemyBoardTargets[0].position;
 		card.transform.localScale = enemyBoardTargets [0].localScale;
+
+		yield return new WaitForSeconds(waitTime);
         enemy.PlayCard(card);
     }
 }

--- a/Assets/Scripts/CardPlayer.cs
+++ b/Assets/Scripts/CardPlayer.cs
@@ -11,54 +11,54 @@ using System.Collections.Generic;
 
 public class CardPlayer : MonoBehaviour {
 
-    string cardPlayerName; // Name of character
+	protected GameController gameController;
+	protected UIManager UImanager;
+	protected Tuning tuning;
 
-    List<CardObject> cards = new List<CardObject>(); // Reference to cards in hand
+    protected string cardPlayerName; // Name of character
+    protected List<CardObject> hand = new List<CardObject>(); // Reference to cards in hand
+	protected Deck deck;
 
-    public void PlayCard(CardObject cardObject)
+	protected virtual void Awake() {
+		deck = GetComponent<Deck> ();
+	}
+
+	protected virtual void Start() {
+		gameController = GameController.gameController;
+		UImanager = UIManager.UImanager;
+		tuning = Tuning.tuning;
+	}
+
+    public virtual void PlayCard(CardObject cardObject)
     {
 		CardInfo playedCardInfo = cardObject.GetCardInfo();
-        // Temporary, don't want to hard code this
-        if (cardPlayerName == "Lex")
-        {
-			int pointsChange = playedCardInfo.points;
-
-			if (pointsChange > 0) {
-				EventController.Event("PointIncrease");
-			}
-
-            Player.player.ChangeStats(pointsChange, 0, 0);
-			GameController.gameController.Turn ();
-        }
         string cardName = cardObject.GetCardInfo().title;
         Debug.Log(cardName + " has been played by " + cardPlayerName);
         RemoveCardFromHand(cardObject);
-		string message = "";
-		if (cardPlayerName == "Enemy") {
-			message += "                     --------->\n";
-		}
-		message += cardPlayerName + " just played " + cardName + ".\nIt has _____ effect.";
-		if (cardPlayerName == "Enemy") {
-			message += "\nTap to read more about it!";
-		}
-		UIManager.UImanager.ShowPopup(message);
+
+		string message = cardPlayerName + " just played " + cardName + ".\nIt has _____ effect.\nTap to read more about it!";
+		Debug.Log (UImanager == null);
+		UImanager.ShowPopup(message);
 	}
 
-    public List<CardObject> GetCards()
+	public Deck GetDeck() {
+		return deck;
+	}
+
+    public List<CardObject> GetHand()
     {
-        return cards;
+        return hand;
     }
-
-
+	
     public void AddCardToHand(CardObject cardObject)
     {
-        cards.Add(cardObject);
+        hand.Add(cardObject);
     }
 
     public void RemoveCardFromHand(CardObject cardObject)
     {
-        cards.Remove(cardObject);
-        Debug.Log("Cards left in " + cardPlayerName + "\'s hand: " + cards.Count.ToString());
+        hand.Remove(cardObject);
+        Debug.Log("Cards left in " + cardPlayerName + "\'s hand: " + hand.Count.ToString());
     }
 
     public void SetName(string name)
@@ -66,7 +66,7 @@ public class CardPlayer : MonoBehaviour {
         cardPlayerName = name;
     }
 
-	public int NumberOfCardsOnHand () {
-		return cards.Count;
+	public int NumberOfCardsInHand () {
+		return hand.Count;
 	}
 }

--- a/Assets/Scripts/Deck.cs
+++ b/Assets/Scripts/Deck.cs
@@ -25,7 +25,7 @@ public class Deck : MonoBehaviour {
     void Start()
     {
         gameController = GameController.gameController;
-        deckShuffling = GetComponent<DeckShuffling>();
+        deckShuffling = gameObject.AddComponent<DeckShuffling>();
         cards = new List<CardInfo>();
         MakeTestDeck();
     }

--- a/Assets/Scripts/DiscardPile.cs
+++ b/Assets/Scripts/DiscardPile.cs
@@ -7,7 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 public class DiscardPile : MonoBehaviour {
-
+/*
     public string discardType;
 
     CardObject selectedCard;
@@ -75,4 +75,5 @@ public class DiscardPile : MonoBehaviour {
             selectedCard = null;
         }
     }
+*/
 }

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -2,21 +2,16 @@
 using System.Collections;
 using System.Collections.Generic;
 
-public class EnemyBehavior : MonoBehaviour {
+public class EnemyBehavior : CardPlayer {
 
-    CardPlayer cardPlayer;
+	void Awake() {
+		base.Awake ();
+	}
 
-	//Placeholder for the enemy's hand
-	List<CardObject> hand = new List<CardObject>();
-
-	GameController gameController;
-
-    void Awake()
+    void Start()
     {
-		gameController = GameController.gameController;
-        cardPlayer = GetComponent<CardPlayer>();
-        cardPlayer.SetName("Enemy");
-		hand = cardPlayer.GetCards();
+		cardPlayerName = "Enemy";
+		base.Start ();
     }
 
 	//Method to test playability of card in current state
@@ -32,8 +27,7 @@ public class EnemyBehavior : MonoBehaviour {
         }
 		return false;
 	}
-
-
+	
 	//TODO talk with design team to determine how a real player might value their cards
 	//TODO Change the behavior of enemy selction depending on what kind of enemy it is.
 

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -19,8 +19,8 @@ public class GameController : MonoBehaviour {
 	private Deck playerDeck;
 	private Deck enemyDeck;
 
-	private CardPlayer enemy;
-	private CardPlayer player;
+	private EnemyBehavior enemy;
+	private Player player;
 
 	private gameState currState;
 	private gameState[] previousTerrain = new gameState[6];
@@ -36,12 +36,11 @@ public class GameController : MonoBehaviour {
 	public bool isGrandmaAlive;
 
 	public UIManager UImanager;
+	public Tuning tuning;
 
 	//TODO associate with unwritten move home. For alpha win if points is good.
 	// win conditions varibles
 	int winPoints;
-	int winGold;
-	int winSalvage;
 
 	void Awake() {
 		gameController = this;
@@ -53,25 +52,25 @@ public class GameController : MonoBehaviour {
 		UImanager = UIManager.UImanager;
 		UImanager.SetupUI ();
 
+		tuning = Tuning.tuning;
+
 		days = 0;
 		SetDawn ();
 
 		terrainIndex = 1;
 
-		winPoints = 30;
-		winGold = 25;
-		winSalvage = 40;
+		winPoints = tuning.winPoints;
 
 		isFatherAlive = true;
 		isSisterAlive = true;
 		isGrandmaAlive = true;
 
 		cardGame = GetComponent<CardGame>();
-		cardGame.SetupCardGame ();
 		enemy = cardGame.enemy;
 		player = cardGame.player;
-		playerDeck = cardGame.playerDeck;
-		enemyDeck = cardGame.enemyDeck;
+		playerDeck = player.GetDeck();
+		enemyDeck = enemy.GetDeck();
+		cardGame.SetupCardGame (playerDeck, enemyDeck);
 
 		cardTemplates = new GameObject[2] {cardGame.playerCardTemplate, cardGame.enemyCardTemplate};
 		cardCanvas = cardGame.cardCanvas;
@@ -120,7 +119,7 @@ public class GameController : MonoBehaviour {
 		case 0:		
 			// make player discard a card if hand is full
 			// TODO change this so player can choose between discarding new card or some old card
-			if (player.NumberOfCardsOnHand () == 5) {
+			if (player.NumberOfCardsInHand () == tuning.handLimit) {
 				UImanager.ShowPopup ("Hand full! Discard at least one card to draw another one.");
 			}
 			//Deals Cards to the player
@@ -141,7 +140,7 @@ public class GameController : MonoBehaviour {
 				//enemy.PlayCard(usedCard);
 			//}
 
-			cardGame.showEnemyCard ();
+			cardGame.waitAndShowEnemyCard (tuning.enemyWaitTime);
 
 			phase = (phase + 1) % 6;
 			SetAfternoon ();
@@ -154,7 +153,7 @@ public class GameController : MonoBehaviour {
 			if (usedCard != null) {
 				enemy.PlayCard(usedCard);
 			}*/
-			cardGame.showEnemyCard ();
+			cardGame.waitAndShowEnemyCard (tuning.enemyWaitTime);
 			phase = (phase + 1) % 6;
 			SetDusk ();
 			break;
@@ -165,7 +164,7 @@ public class GameController : MonoBehaviour {
 			if (usedCard != null) {
 				enemy.PlayCard(usedCard);
 			}*/
-			cardGame.showEnemyCard ();
+			cardGame.waitAndShowEnemyCard (tuning.enemyWaitTime);
 			phase = (phase + 1) % 6;
 			SetNight ();
 			break;
@@ -174,7 +173,7 @@ public class GameController : MonoBehaviour {
 		case 4:			
 			// make player discard a card if hand is full
 			// TODO change this so player can choose between discarding new card or some old card
-			if (player.NumberOfCardsOnHand () == 5) {
+			if (player.NumberOfCardsInHand () == tuning.handLimit) {
 				UImanager.ShowPopup ("Hand full! Discard at least one card to draw another one.");
 			}
 			//Deals Cards to the player
@@ -193,7 +192,7 @@ public class GameController : MonoBehaviour {
 			if (usedCard != null) {
 				enemy.PlayCard(usedCard);
 			}*/
-			cardGame.showEnemyCard ();
+			cardGame.waitAndShowEnemyCard (tuning.enemyWaitTime);
 			//This time phase will loop back to 0
 			phase = (phase + 1) % 6;
 			SetDawn ();
@@ -243,22 +242,12 @@ public class GameController : MonoBehaviour {
 		winPoints += amount;
 	}
 
-	// raise winning condition for gold
-	public void raiseGold (int amount) {
-		winGold += amount;
-	}
-
-	// raise winning condition for salvage
-	public void raiseSalvage (int amount) {
-		winSalvage += amount;
-	}
-
 	// check for winning conditions
 	public bool Win () {
 		// gets player's stats
 		int[] stats = Player.player.GetStats();
 
-		if (stats [0] >= winPoints || stats [1] >= winGold || stats [2] >= winSalvage) {
+		if (stats [0] >= winPoints) {
 			return true;
 		} 
 		else {

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -2,56 +2,63 @@
 using System.Collections;
 using System.Collections.Generic;
 
-public class Player : MonoBehaviour {
+public class Player : CardPlayer {
 
 	public static Player player; // Static instance of this class
-	public UIManager UImanager;
-    Tuning tuning;
 
 	// Stat variables
     int points;
-    int gold;
-    int salvage;
 
-	string[] inventory = new string[5];
-    CardPlayer cardPlayer;
+	// Card Player variables
+	CardObject selectedCard;
 
 	void Awake() {
 		player = this;
+		base.Awake ();
 	}
 
 	void Start() {
-		UImanager = UIManager.UImanager;
-
-		// Assigns starting stats from tuning object
-        player.tuning = Tuning.tuning;
-		player.points = tuning.startingPoints;
-		player.gold = tuning.startingGold;
-		player.salvage = tuning.startingSalvage;
-		for (int i = 0; i < inventory.Length; i++){
-			player.inventory [i] = "";
-		}
-		// Calls UIManager to display the stats
-		UImanager.SetStats ();
-
-        player.cardPlayer = GetComponent<CardPlayer>();
-        cardPlayer.SetName("Lex");
+		base.Start ();
+		cardPlayerName = "Lex";
 	}
-
-	//TODO add bool functions for item checks.
 
 	// This allows other objects to get stats from Player without reassigning them
     public int[] GetStats()
     {
-        return new int[3] { points, gold, salvage };
+		return new int[1] {points};
     }
 
-    public void ChangeStats(int pointsChange, int goldChange, int salvageChange)
+    public void ChangeStats(int pointsChange)
     {
         points += pointsChange;
-        gold += goldChange;
-        salvage += salvageChange;
-
-        UImanager.SetStats();
+        UImanager.SetStats(points);
     }
+
+	public override void PlayCard(CardObject cardObject) {
+		selectedCard = cardObject;
+		UImanager.ShowConfirmMenu(true);
+	}
+
+	public void Confirm(bool isConfirmed) {
+		if (isConfirmed) {
+			CardInfo playedCardInfo = selectedCard.GetCardInfo();
+			string cardName = playedCardInfo.title;
+			RemoveCardFromHand(selectedCard);
+			
+			int pointsChange = playedCardInfo.points;
+			
+			if (pointsChange > 0) {
+				EventController.Event("PointIncrease");
+			}
+			
+			ChangeStats(pointsChange);
+			gameController.Turn ();
+			
+			Debug.Log("Lex just played" + cardName);
+		}
+		else {
+			Debug.Log("Lex cancelled");
+		}
+		selectedCard = null;
+	}
 }

--- a/Assets/Scripts/Tuning.cs
+++ b/Assets/Scripts/Tuning.cs
@@ -15,7 +15,7 @@ public class Tuning : MonoBehaviour {
     public static Tuning tuning;
 
 	// Win Condition
-	public int numOfCardsToWin;
+	public int winPoints;
 
     // Player variables
     public int startingGold;
@@ -24,8 +24,10 @@ public class Tuning : MonoBehaviour {
 
     // Card Game variables
     public int numOfStartingCards;
+	public int handLimit;
     public float scaleFactor;
     public Vector3 cardScale;
+	public float enemyWaitTime; // Time enemy takes to pick a card
 
 	public int travelCost;
 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -28,7 +28,8 @@ public class UIManager : MonoBehaviour {
 
 	// Reference to popups
 	public GameObject pauseMenu;
-	public GameObject popupObject; // object itself
+	public GameObject confirmMenu;
+	public GameObject notificationPopup; // object itself
 	Popup popup; // popup script
 
 	void Awake() {
@@ -40,16 +41,17 @@ public class UIManager : MonoBehaviour {
 		tuning = Tuning.tuning;
 		gameController = GameController.gameController;
 
-		popup = popupObject.GetComponent<Popup> ();
+		SetStats (tuning.startingPoints);
+
+		popup = notificationPopup.GetComponent<Popup> ();
 		hideAllPopups ();
 		//popupObject.SetActive(false); // Hide popup
 	}
 
-	// This is called from Player
-    public void SetStats()
+	// This is called from Player and SetupUI
+    public void SetStats(int points)
     {
-        int[] playerStats = player.GetStats();
-        pointsText.text = "Points: " + playerStats[0].ToString();
+        pointsText.text = "Points: " + points.ToString();
     }
 
 	// This is called from GameController in SetTerrain()
@@ -59,15 +61,11 @@ public class UIManager : MonoBehaviour {
 
 	// This is called when the Travel Button is pressed
 	public void Travel() {
-		if (tuning.travelCost <= player.GetStats () [2]) {
-			// Player can afford
-			EventController.Event("Decrease");
-			gameController.MoveTerrain();
-			player.ChangeStats (0, 0, -tuning.travelCost);
-			GameController.gameController.Turn();
-		} else {
-			ShowPopup("I'm sorry. You do not have enough salvage to travel.");
-		}
+		// Player can afford
+		EventController.Event("Decrease");
+		gameController.MoveTerrain();
+		GameController.gameController.Turn();
+		ShowPopup("You moved to a new terrain!");
 	}
 
 	// This is called when Pause Button is pressed (pauseGame = true)
@@ -87,13 +85,30 @@ public class UIManager : MonoBehaviour {
 	}
 
 	public void ShowPopup(string message) {
-		popupObject.SetActive (true);
+		notificationPopup.SetActive (true);
 		popup.SetText (message);
 	}
 
+	public void ShowConfirmMenu(bool showMenu) {
+		confirmMenu.SetActive (showMenu);
+	}
+
+	// This is called by the Yes and No Buttons on the Confirmation Prompt
+	public void Confirm(bool confirm) {
+		if (confirm) {
+			Debug.Log ("Confirmed.");
+			player.Confirm(true);
+		} else {
+			Debug.Log ("Cancelled.");
+			player.Confirm(false);
+		}
+		ShowConfirmMenu (false);;	    
+	}
+
 	void hideAllPopups() {
-		popupObject.SetActive (false);
+		notificationPopup.SetActive (false);
 		pauseMenu.SetActive (false);
+		confirmMenu.SetActive (false);
 	}
 
 	public void PlayButtonPressSFX () {


### PR DESCRIPTION
SCENE
**UI-Mockup.unity**
- Removed Travel button
- Removed PlayerDeck and EnemyDeck objects (they are now components of Player and Enemy objects)
- Added Confirmation Popup (with Text, Yes and No Buttons)

SCRIPTS
**CardGame.cs**
- References to CardPlayers now direct to their subclasses (Player and EnemyBehavior)
- SetupCardGame now takes two Decks as input (this fixed a few NullReferenceExceptions)
- showEnemyCard function became waitAndShowEnemyCard which uses a delay

**CardPlayer.cs**
- Became a parent class of Player and Enemy Behavior
- Contains virtual PlayCard function
- Contains methods GetDeck, GetHand, AddCardToHand, RemoveCardFromHand, SetName, NumOfCardsInHand
- Variables for GameController, UIManager, and Tuning for child classes to reference

**Deck.cs**
- Now adds a DeckShuffling component programmatically

**DiscardPile.cs**
- Completely commented out

**EnemyBehavior.cs**
- Now subclass of CardPlayer
- Removes assignments that are inherited from the parent class

**GameController.cs**
- Reference to Tuning object
- CardPlayer variables are now their corresponding subclass (Player, EnemyBehavior)
- Gets Deck from CardPlayer subclasses
- Card limit in hand (handLimit) is gotten from Tuning
- Removed win conditions for gold and salvage

**Player.cs**
- Now subclasses from CardPlayer
- Variable for selected card
- PlayCard method that asks for confirmation from the player
- Added Confim method that is called from the Yes or No Buttons on the Confirm Menu
- GetStats and ChangeStats now only deal with points (not gold and salvage)

**UIManager.cs**
- Reference to confirmMenu
- Variable popup renamed to notificationPopup
- Sets initial stats from Tuning, and not player (fixed NullReferenceExceptions)
- SetStats now takes an integer as input
- Travel no longer has a condition since salvage was removed
- Added methods ShowConfirmMenu, Confirm, and hideAllPopups
