### PR TITLE
Fixed NullReferenceException in Deck

### DIFF
--- a/Assets/Scenes/UI-Mockup.unity
+++ b/Assets/Scenes/UI-Mockup.unity
@@ -2026,7 +2026,6 @@ GameObject:
   m_Component:
   - 4: {fileID: 1029208977}
   - 114: {fileID: 1029208976}
-  - 114: {fileID: 1029208978}
   - 114: {fileID: 1029208979}
   m_Layer: 0
   m_Name: Player
@@ -2058,17 +2057,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
---- !u!114 &1029208978
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1029208975}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fcaf76672fa77f04884f86b6162de33b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1029208979
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2090,7 +2078,6 @@ GameObject:
   m_Component:
   - 4: {fileID: 1111293361}
   - 114: {fileID: 1111293360}
-  - 114: {fileID: 1111293362}
   - 114: {fileID: 1111293363}
   m_Layer: 0
   m_Name: Enemy
@@ -2122,17 +2109,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
---- !u!114 &1111293362
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1111293359}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fcaf76672fa77f04884f86b6162de33b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1111293363
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2922,7 +2898,6 @@ Camera:
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
-  m_TargetEye: 3
   m_HDR: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
@@ -3536,7 +3511,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: .196078435, g: .196078435, b: .196078435, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 7

--- a/Assets/Scripts/CardGame.cs
+++ b/Assets/Scripts/CardGame.cs
@@ -49,6 +49,8 @@ public class CardGame : MonoBehaviour {
 
 		this.playerDeck = playerDeck;
 		this.enemyDeck = enemyDeck;
+        playerDeck.Init();
+        enemyDeck.Init();
 
 		playerCards = player.GetHand();
 		enemyCards = enemy.GetHand();
@@ -68,7 +70,6 @@ public class CardGame : MonoBehaviour {
 	// Deals the number of starting cards to the player
     public void DealCards(int numOfCards, Deck deck, Transform[] handTargets, CardPlayer cardPlayer)
     {
-		deck = cardPlayer.GetDeck ();
         for (int i = 0; i < numOfCards; i++)
         {
             Transform currentTransform = handTargets[i];

--- a/Assets/Scripts/CardGame.cs
+++ b/Assets/Scripts/CardGame.cs
@@ -61,8 +61,6 @@ public class CardGame : MonoBehaviour {
 
 	public void BeginCardGame() {
 
-		//playerDeck = player.GetDeck ();
-		//enemyDeck = enemy.GetDeck ();
 		DealCards(numOfStartingCards, playerDeck, playerHandTargets, player);
 		DealCards(numOfStartingCards, enemyDeck, enemyHandTargets, enemy);
 		

--- a/Assets/Scripts/CardPlayer.cs
+++ b/Assets/Scripts/CardPlayer.cs
@@ -29,30 +29,18 @@ public class CardPlayer : MonoBehaviour {
 		tuning = Tuning.tuning;
 	}
 
-
-
-
-
     public virtual void PlayCard(CardObject cardObject)
     {
-		/*CardInfo playedCardInfo = cardObject.GetCardInfo();
-
-      
-			CardGame.Instance.SetPositionFree (cardObject.GetHandPosition ()); // Set hand position as free
-			GameController.gameController.Turn ();*/
-        }
-
-
-
-	/*
+		CardInfo playedCardInfo = cardObject.GetCardInfo();
+        CardGame.Instance.SetPositionFree (cardObject.GetHandPosition ()); // Set hand position as free
+		GameController.gameController.Turn ();
 
         string cardName = cardObject.GetCardInfo().title;
         Debug.Log(cardName + " has been played by " + cardPlayerName);
         RemoveCardFromHand(cardObject);
 
 		string message = cardPlayerName + " just played " + cardName + ".\nIt has _____ effect.\nTap to read more about it!";
-		Debug.Log (UImanager == null);
-		UImanager.ShowPopup(message);*/
+		UImanager.ShowPopup(message);
 	}
 
 	public Deck GetDeck() {

--- a/Assets/Scripts/Deck.cs
+++ b/Assets/Scripts/Deck.cs
@@ -22,7 +22,7 @@ public class Deck : MonoBehaviour {
     DeckShuffling deckShuffling;
     GameController gameController;
 
-    void Start()
+    public void Init()
     {
         gameController = GameController.gameController;
         deckShuffling = gameObject.AddComponent<DeckShuffling>();


### PR DESCRIPTION
SCENE
**UI-Mockup.unity**
- Removed CardPlayer scripts from Player and Enemy objects (they don't need it because Player and EnemyBehavior are subclasses)
- Changed color of Confirmation Text to white

SCRIPTS
**Deck** and **CardGame**
- Now has an Init function that replaces Start. 
- This is called from CardGame to ensure the Decks are set up before the call to DrawCard.
