### PR TITLE
Prevent selection multiple cards

### DIFF
--- a/Assets/Scripts/CardObject.cs
+++ b/Assets/Scripts/CardObject.cs
@@ -13,6 +13,9 @@ using System.Collections;
 
 public class CardObject : MonoBehaviour {
 
+    protected Player player;
+    protected UIManager UImanager;
+
     // UI Components
     protected Text[] text;
     protected Text titleText;
@@ -21,6 +24,7 @@ public class CardObject : MonoBehaviour {
     protected Text description;
     protected Image[] images;
     protected Sprite cardBackground;
+    protected ClickManager clickManager;
 
     protected CardPlayer owner; // Who has this card in their hand, if anyone
     protected Land[] acceptedTerrains; // Terrains this card can be played on
@@ -34,6 +38,7 @@ public class CardObject : MonoBehaviour {
     protected bool played; // Whether the card has been played
     protected bool touchingBoard;
     protected bool hasShrunk;
+    protected Vector3 lastPosition;
 
     protected CardInfo myCardInfo;
 
@@ -48,8 +53,11 @@ public class CardObject : MonoBehaviour {
     void Start()
     {
         tuning = Tuning.tuning;
+        player = Player.player;
+        UImanager = UIManager.UImanager;
         float scaleFactor = tuning.scaleFactor; // Get scale factor from tuning object
         scaleVector = new Vector3(scaleFactor, scaleFactor); // This vector is added to local scale on Grow()
+        clickManager = new ClickManager();
 	}
 
     // This is called in CardGame and overridden in CardObject subclasses (PlayerCardObject and EnemyCardObject)
@@ -93,8 +101,7 @@ public class CardObject : MonoBehaviour {
         CheckOwner();
         owner.PlayCard(this);
         played = true;
-        PlayEffect();
-        
+        PlayEffect();  
     }
 
     // Overridden by Discovery Cards, etc.
@@ -182,7 +189,10 @@ public class CardObject : MonoBehaviour {
     public virtual void OnMouseDown() {
 		EventController.Event("DrawCard");
 
-		Grow();
+        if (clickManager.DoubleClick())
+        {
+            Grow();
+        }
         // Push to front
         transform.SetAsLastSibling();
     }
@@ -193,6 +203,19 @@ public class CardObject : MonoBehaviour {
 
     public void Grow()
     {
+        CardObject selectedCard = player.SelectedCard;
+        CardObject viewedCard = player.ViewedCard;
+        Debug.Log(viewedCard == null);
+        if (selectedCard != null && selectedCard != this)
+        {
+            player.ReturnCardToHand();
+        }
+        if (viewedCard != null & viewedCard != this)
+        {
+            player.ReturnViewedCard();
+        }
+        lastPosition = transform.localPosition;
+        Debug.Log(lastPosition);
         transform.localPosition = tuning.largeCardPosition;
         transform.localScale = tuning.largeCardScale;
         hasShrunk = false;
@@ -200,6 +223,7 @@ public class CardObject : MonoBehaviour {
 
     public void Shrink()
     {
+        transform.localPosition = lastPosition;
 		transform.localScale = tuning.cardScale;
 		hasShrunk = true;
     }

--- a/Assets/Scripts/EnemyCardObject.cs
+++ b/Assets/Scripts/EnemyCardObject.cs
@@ -10,4 +10,16 @@ public class EnemyCardObject : CardObject {
 
         SetCardBackground(acceptedTerrains[0].enemyCardArt);
     }
+
+    public override void OnMouseDown()
+    {
+        if (clickManager.DoubleClick())
+        {
+            player.ViewedCard = this;
+            Grow();
+            // Push to front
+            transform.SetAsLastSibling();
+            UImanager.ShowActionIcons(false);
+        }
+    }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -11,7 +11,8 @@ public class Player : CardPlayer {
 	int points;
 	
 	// Card Player variables
-	CardObject selectedCard;
+	CardObject selectedCard; // Player Card Object
+    CardObject viewedCard; // Enemy Card Object the player is viewing
 	
 	void Awake() {
 		player = this;
@@ -82,9 +83,29 @@ public class Player : CardPlayer {
         }		
 	}
 
+    // Returns currently selected card to hand
+    public void ReturnCardToHand()
+    {
+        selectedCard.Shrink();
+        selectedCard = null;
+    }
+
+    public void ReturnViewedCard()
+    {
+        Debug.Log("trying to return viewed card");
+        viewedCard.Shrink();
+        viewedCard = null;
+    }
+
     public CardObject SelectedCard
     {
         get { return selectedCard; }
         set { selectedCard = value; }
+    }
+
+    public CardObject ViewedCard
+    {
+        get { return viewedCard; }
+        set { viewedCard = value; }
     }
 }

--- a/Assets/Scripts/PlayerCardObject.cs
+++ b/Assets/Scripts/PlayerCardObject.cs
@@ -4,9 +4,6 @@ using System.Collections;
 
 public class PlayerCardObject : CardObject {
 
-    ClickManager clickManager;
-    UIManager UImanager;
-
     Text goldText;
     Text pointsText;
     Text salvageText;
@@ -31,12 +28,6 @@ public class PlayerCardObject : CardObject {
 
         // Add Click and Drag functionality to this object
         //gameObject.AddComponent<ClickAndDrag>();
-
-        // Add reference to Click Manager
-        clickManager = new ClickManager();
-
-        // Add refernce to UI Manager
-        UImanager = UIManager.UImanager;
     }
 
     public override void OnMouseDown()


### PR DESCRIPTION
Prevents player from selecting or viewing multiple cards.
Now if a player double taps another card, the currently selected card will go back into their hand.
Similarly, if a player is viewing the enemy card and then goes to play a card, the enemy card will go back to its spot on the screen.
